### PR TITLE
http/https issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,10 @@ const blocked_region = ['CN', 'KP', 'SY', 'PK', 'CU']
 // IP addresses which you wish to block from using your service.
 const blocked_ip_address = ['0.0.0.0', '127.0.0.1']
 
+//Fix http/https issue
+const http = "http://"
+const https = "https://"
+
 addEventListener('fetch', event => {
     event.respondWith(fetchAndApply(event.request));
 })
@@ -24,6 +28,13 @@ async function fetchAndApply(request) {
     const user_agent = request.headers.get('user-agent');
     let response = null;
     let url = request.url;
+
+	//Fix http/https issue
+	if (url.startsWith(http)) {
+		url = url.replace(http, https);
+		response = Response.redirect(url);
+		return response;
+	}
 
     if (await device_status(user_agent)){
         upstream_domain = upstream


### PR DESCRIPTION
使用 iOS 的浏览器 (Safari 和 Chrome) 时，直接输入网址不加 _https://_ 会默认使用 http 方式访问 workers，导致无法显示代理网站

**解决方法：**
将 url 的 _http://_ 替换为 _https://_，然后重定向